### PR TITLE
fixed typeof condition

### DIFF
--- a/es/JasonTheMiner.js
+++ b/es/JasonTheMiner.js
@@ -66,8 +66,8 @@ class JasonTheMiner {
 
     if (
       category === 'load' && (
-        processor.prototype.getConfig !== 'function' ||
-        processor.prototype.buildLoadParams !== 'function'
+        typeof processor.prototype.getConfig !== 'function' ||
+        typeof processor.prototype.buildLoadParams !== 'function'
       )
     ) {
       throw new TypeError(`Invalid load processor "${name}"! Missing "getConfig" and/or "buildLoadParams" method.`);


### PR DESCRIPTION
Every time i try to register a loader i get this error
```
.../jason-the-miner/es/JasonTheMiner.js:73
      throw new TypeError(`Invalid load processor "${name}"! Missing "getConfig" and/or "buildLoadParams" method.`);
```
I think it's because this `typeof` missing